### PR TITLE
errorをobservableで返す

### DIFF
--- a/Colombia/Sources/APIClient/APIClient.swift
+++ b/Colombia/Sources/APIClient/APIClient.swift
@@ -24,7 +24,7 @@ struct APIClient {
                     let decodeData = try decoder.decode(T.Response.self, from: resultData)
                     observer.onNext(decodeData)
                 } catch let error {
-                    print(error)
+                    observer.onError(error)
                 }
             }
             task.resume()

--- a/Colombia/Sources/APIClient/APIClient.swift
+++ b/Colombia/Sources/APIClient/APIClient.swift
@@ -19,7 +19,12 @@ struct APIClient {
             let url = requestable.url
             let request = URLRequest(url: url)
             let task = URLSession.shared.dataTask(with: request) { resultData, response, error in
-                guard let resultData = resultData else { return }
+                guard let resultData = resultData else {
+                    if let error = error {
+                        observer.onError(error)
+                    }
+                    return
+                }
                 do {
                     let decodeData = try decoder.decode(T.Response.self, from: resultData)
                     observer.onNext(decodeData)


### PR DESCRIPTION
## 関連するIssues
close #26 
## 変更内容
エラーをobservableでリターン
`print(error)`  ->  `observer.onError(error)`